### PR TITLE
Use subproject artifacts

### DIFF
--- a/samples/default/build.gradle
+++ b/samples/default/build.gradle
@@ -14,18 +14,18 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 
-eclipse.project.name = 'openid-connect-server-spring-boot-samples-default' 
+eclipse.project.name = 'openid-connect-server-spring-boot-samples-default'
 
 repositories {
 	mavenCentral()
 }
 
 dependencies {
-	compile('org.springframework.boot:spring-boot-starter')
-	 
-	compile ('net.simpledynamics:openid-connect-server-spring-boot-config:0.1.4-SNAPSHOT')
-	compile ('net.simpledynamics:openid-connect-server-spring-boot-ui-thymeleaf:0.1.4-SNAPSHOT')
-	compile ('org.mitre:openid-connect-server:1.3.0')
+    compile('org.springframework.boot:spring-boot-starter')
+    compile ('org.mitre:openid-connect-server:1.3.0')
+
+    compile project(':openid-connect-server-spring-boot-config')
+    compile project(':openid-connect-server-spring-boot-ui-thymeleaf')
 
     runtime ('com.h2database:h2:1.4.192')
 }

--- a/samples/simple-ui/build.gradle
+++ b/samples/simple-ui/build.gradle
@@ -23,8 +23,8 @@ repositories {
 dependencies {
 	compile("org.springframework.boot:spring-boot-starter")
 	compile("org.springframework.boot:spring-boot-devtools")
-	    
-	compile("net.simpledynamics:openid-connect-server-spring-boot-config:0.1.4-SNAPSHOT")
+
+    compile project(':openid-connect-server-spring-boot-config')
 	compile ('org.mitre:openid-connect-server:1.3.0')
 
 	compile("org.webjars:jquery:3.1.1")


### PR DESCRIPTION
samples/* are referencing openid-connect-server-spring-boot-* as
regular dependencies instead of project dependencies. This is causing
Gradle to download them from Maven Central instead of using the
artifacts it's just built. As a result, any changes to
openid-connect-server-spring-boot-* are ignored by samples/*.

Use "compile project" dependencies instead.