### PR TITLE
Fix Thymeleaf Error

### DIFF
--- a/openid-connect-server-spring-boot-ui-thymeleaf/src/main/resources/templates/approve.html
+++ b/openid-connect-server-spring-boot-ui-thymeleaf/src/main/resources/templates/approve.html
@@ -90,7 +90,7 @@
 											<li data-th-if="${not #strings.isEmpty(client.clientUri)}"><span data-th-text="#{approve.home_page}"/>: <a data-th-href="${ client.clientUri }" data-th-text="${ client.clientUri }"></a></li>
 											<li data-th-if="${not #strings.isEmpty(client.policyUri)}"><span data-th-text="#{approve.policy}"/>: <a data-th-href="${ client.policyUri }" data-th-text="${ client.policyUri }"></a></li>
 											<li data-th-if="${not #strings.isEmpty(client.tosUri)}"><span data-th-text="#{approve.terms}"/>: <a data-th-href="${ client.tosUri }" data-th-text="${ client.tosUri }"></a></li>
-											<li data-th-if="${not #strings.isEmpty(contacts))}"><span data-th-text="|#{approve.contacts} ${ contacts }|"/></li>
+											<li data-th-if="${not #strings.isEmpty(contacts)}"><span data-th-text="|#{approve.contacts} ${ contacts }|"/></li>
 										</ul>
 									</div>
 								</th-block>

--- a/openid-connect-server-spring-boot-ui-thymeleaf/src/main/resources/templates/approveDevice.html
+++ b/openid-connect-server-spring-boot-ui-thymeleaf/src/main/resources/templates/approveDevice.html
@@ -90,7 +90,7 @@
 											<li data-th-if="${not #strings.isEmpty(client.clientUri)}"><span data-th-text="#{approve.home_page}"></span>: <a data-th-href="${ client.clientUri }" data-th-text="${ client.clientUri }"></a></li>
 											<li data-th-if="${not #strings.isEmpty(client.policyUri)}"><span data-th-text="#{approve.policy}"></span>: <a data-th-href="${ client.policyUri }" data-th-text="${ client.policyUri }"></a></li>
 											<li data-th-if="${not #strings.isEmpty(client.tosUri)}"><span data-th-text="#{approve.terms}"></span>: <a data-th-href="${ client.tosUri }" data-th-text="${ client.tosUri }"></a></li>
-											<li data-th-if="${not #strings.isEmpty(contacts))}"><span data-th-text="|#{approve.contacts} ${ contacts }|"></span></li>
+											<li data-th-if="${not #strings.isEmpty(contacts)}"><span data-th-text="|#{approve.contacts} ${ contacts }|"></span></li>
 										</ul>
 									</div>
 								</th-block>


### PR DESCRIPTION
When rendering the approve page and the approveDevice pages, the server was throwing a Thymeleaf error attempting to render the page.

```
org.springframework.expression.spel.SpelParseException: EL1041E: After parsing a valid expression, there is still more data in the expression: 'rparen())'
```